### PR TITLE
Add missing alias

### DIFF
--- a/src/PaymentSourcesTools.php
+++ b/src/PaymentSourcesTools.php
@@ -51,7 +51,8 @@ class PaymentSourcesTools extends Module
 	 */
 	public function init()
 	{
-
+		
+		Craft::setAlias('@michaelrog/paymentsourcestools', __DIR__);
 		Craft::setAlias('@paymentSourcesToolsTemplates', __DIR__ . DIRECTORY_SEPARATOR . 'web/templates');
 		parent::init();
 


### PR DESCRIPTION
Fixes this error: `Exception 'yii\base\InvalidArgumentException' with message 'Invalid path alias: @michaelrog/paymentsourcestools/controllers'`